### PR TITLE
Include helm charts to install Kruize on minikube

### DIFF
--- a/charts/kruize/.helmignore
+++ b/charts/kruize/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kruize/README.md
+++ b/charts/kruize/README.md
@@ -8,8 +8,9 @@ Kruize is an intelligent resource optimization platform that helps you optimize 
 
 ## Prerequisites
 
-- Kubernetes 1.19+ or OpenShift 4.x+
+- Kubernetes 1.23.0+ or OpenShift 4.10+
 - Helm 3.0+
+- [Prometheus](https://github.com/prometheus/prometheus) (for Minikube, Kind clusters)
 
 ## Installing the Chart
 

--- a/charts/kruize/README.md
+++ b/charts/kruize/README.md
@@ -155,6 +155,7 @@ The following table lists the configurable parameters of the Kruize chart and th
 | `db.adminUser` | Admin user for Kruize DB container | `admin` |
 | `db.adminPassword` | Admin password for Kruize DB container | `admin` |
 | `db.name` | Name of the Kruize DB | `kruizeDB` |
+| `db.includeReleaseNameInDbName` | Include release name in database name for multi-instance support | `false` |
 | `db.sslMode` | SSL mode for database connection | `require` |
 
 ### Kruize UI Parameters

--- a/charts/kruize/README.md
+++ b/charts/kruize/README.md
@@ -52,11 +52,25 @@ The following table lists the configurable parameters of the Kruize chart and th
 | `kruize.service.type` | Kruize service type | `NodePort` |
 | `kruize.service.port` | Kruize service port | `8080` |
 
+### Kruize Environment Variables
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `kruize.env[].LOGGING_LEVEL` | Logging level for Kruize | `info` |
+| `kruize.env[].ROOT_LOGGING_LEVEL` | Root logging level | `error` |
+| `kruize.env[].DB_CONFIG_FILE` | Path to database configuration file | `/etc/config/dbconfigjson` |
+| `kruize.env[].KRUIZE_CONFIG_FILE` | Path to Kruize configuration file | `/etc/config/kruizeconfigjson` |
+| `kruize.env[].JAVA_TOOL_OPTIONS` | Java tool options | `-XX:MaxRAMPercentage=80` |
+| `kruize.env[].KAFKA_BOOTSTRAP_SERVERS` | Kafka bootstrap servers | `kruize-kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092` |
+| `kruize.env[].KAFKA_TOPICS` | Kafka topics | `recommendations-topic,error-topic,summary-topic` |
+| `kruize.env[].KAFKA_RESPONSE_FILTER_INCLUDE` | Kafka response filter include patterns | `experiments\|status\|apis\|recommendations\|response\|status_history` |
+| `kruize.env[].KAFKA_RESPONSE_FILTER_EXCLUDE` | Kafka response filter exclude patterns | `""` |
+
 ### Kruize Configuration Parameters
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `kruize.config.clusterType` | Type of cluster (kubernetes/openshift) | `kubernetes` |
+| `kruize.config.clusterType` | Type of cluster | `kubernetes` |
 | `kruize.config.k8sType` | Kubernetes distribution type | `openshift` |
 | `kruize.config.authType` | Authentication type | `""` |
 | `kruize.config.monitoringAgent` | Monitoring agent to use | `prometheus` |
@@ -86,6 +100,36 @@ The following table lists the configurable parameters of the Kruize chart and th
 | `kruize.config.hibernate.showsql` | Show SQL queries | `false` |
 | `kruize.config.hibernate.timezone` | Database timezone | `UTC` |
 
+### Kruize Logging Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `kruize.config.logging.cloudwatch.accessKeyId` | AWS CloudWatch access key ID | `""` |
+| `kruize.config.logging.cloudwatch.logGroup` | CloudWatch log group | `kruize-logs` |
+| `kruize.config.logging.cloudwatch.logStream` | CloudWatch log stream | `kruize-stream` |
+| `kruize.config.logging.cloudwatch.region` | AWS region for CloudWatch | `""` |
+| `kruize.config.logging.cloudwatch.secretAccessKey` | AWS CloudWatch secret access key | `""` |
+| `kruize.config.logging.cloudwatch.logLevel` | CloudWatch log level | `INFO` |
+
+### Kruize Datasource Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `kruize.config.datasource[0].name` | Name of the first datasource | `prometheus-1` |
+| `kruize.config.datasource[0].provider` | Provider type | `prometheus` |
+| `kruize.config.datasource[0].serviceName` | Service name | `prometheus-k8s` |
+| `kruize.config.datasource[0].namespace` | Namespace | `openshift-monitoring` |
+| `kruize.config.datasource[0].url` | Datasource URL | `""` |
+| `kruize.config.datasource[0].authentication.type` | Authentication type | `bearer` |
+| `kruize.config.datasource[0].authentication.credentials.tokenFilePath` | Token file path | `/var/run/secrets/kubernetes.io/serviceaccount/token` |
+| `kruize.config.datasource[1].name` | Name of the second datasource | `thanos-1` |
+| `kruize.config.datasource[1].provider` | Provider type | `prometheus` |
+| `kruize.config.datasource[1].serviceName` | Service name | `thanos-querier` |
+| `kruize.config.datasource[1].namespace` | Namespace | `openshift-monitoring` |
+| `kruize.config.datasource[1].url` | Datasource URL | `""` |
+| `kruize.config.datasource[1].authentication.type` | Authentication type | `bearer` |
+| `kruize.config.datasource[1].authentication.credentials.tokenFilePath` | Token file path | `/var/run/secrets/kubernetes.io/serviceaccount/token` |
+
 ### Kruize Database Parameters
 
 | Parameter | Description | Default |
@@ -103,6 +147,9 @@ The following table lists the configurable parameters of the Kruize chart and th
 | `db.pvc.storageClass` | Storage class for database PVC | `manual` |
 | `db.pvc.storageSize` | Storage size for database PVC | `500Mi` |
 | `db.pvc.hostPath` | Host path for database storage | `/mnt/data` |
+| `db.pvc.accessModes` | Access modes for PVC | `[ReadWriteMany]` |
+| `db.volumeMountPath` | Volume mount path for database data | `/var/lib/pgsql/data` |
+| `db.pgData` | PGDATA environment variable value | `/var/lib/pg_data` |
 | `db.user` | User for Kruize DB container | `admin` |
 | `db.password` | Password for Kruize DB container | `admin` |
 | `db.adminUser` | Admin user for Kruize DB container | `admin` |
@@ -143,6 +190,7 @@ The following table lists the configurable parameters of the Kruize chart and th
 | `rbac.create` | Specifies whether OpenShift-specific RBAC resources should be created | `true` |
 | `nameOverride` | Overrides the name of this Chart | `""` |
 | `fullnameOverride` | Overrides the fully qualified application name | `""` |
+| `networkPolicy.enabled` | Enable NetworkPolicy resources | `false` |
 
 ## Example: Custom Values
 

--- a/charts/kruize/templates/_helpers.tpl
+++ b/charts/kruize/templates/_helpers.tpl
@@ -62,10 +62,9 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
-Get the name for managed deployments.
+Create the name of the deployment.
 */}}
 {{- define "kruize.deploymentName" -}}
-{{- $version := semver .Chart.AppVersion -}}
-{{- printf "%s-v%d" (include "kruize.fullname" .) $version.Major -}}
+{{- include "kruize.fullname" . -}}
 {{- end -}}
 

--- a/charts/kruize/templates/configmap_kruize.yaml
+++ b/charts/kruize/templates/configmap_kruize.yaml
@@ -12,7 +12,7 @@ data:
         "adminPassword": {{ .Values.db.adminPassword | quote }},
         "adminUsername": {{ .Values.db.adminUser | quote }},
         "hostname": "{{ $fullName }}-db-service",
-        "name": {{ printf "%s-%s" .Values.db.name $fullName | quote }},
+        "name": {{ if .Values.db.includeReleaseNameInDbName }}{{ printf "%s-%s" .Values.db.name $fullName | quote }}{{ else }}{{ .Values.db.name | quote }}{{ end }},
         "password": {{ .Values.db.password | quote }},
         "port": {{ .Values.db.service.port | quote }},
         "sslMode": {{ .Values.db.sslMode | quote }},

--- a/charts/kruize/templates/cronjobs.yaml
+++ b/charts/kruize/templates/cronjobs.yaml
@@ -32,7 +32,7 @@ spec:
           containers:
             - name: kruize-cron-create
               image: {{ $image }}
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: {{ .Values.kruize.image.pullPolicy }}
               volumeMounts:
                 - name: config-volume
                   mountPath: /etc/config
@@ -70,7 +70,7 @@ spec:
           containers:
             - name: kruize-cron-delete
               image: {{ $image }}
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: {{ .Values.kruize.image.pullPolicy }}
               volumeMounts:
                 - name: config-volume
                   mountPath: /etc/config

--- a/charts/kruize/templates/kruize_db_deployment.yaml
+++ b/charts/kruize/templates/kruize_db_deployment.yaml
@@ -29,8 +29,10 @@ spec:
               value: {{ .Values.db.user | quote }}
             - name: POSTGRES_DB
               value: {{ printf "%s-%s" .Values.db.name $fullName | quote }}
+            {{- if .Values.db.pgData }}
             - name: PGDATA
-              value: /var/lib/pg_data
+              value: {{ .Values.db.pgData }}
+            {{- end }}
           {{- if or .Values.db.resources.requests.memory .Values.db.resources.requests.cpu .Values.db.resources.limits.memory .Values.db.resources.limits.cpu }}
           resources:
             {{- if or .Values.db.resources.requests.memory .Values.db.resources.requests.cpu }}
@@ -56,7 +58,7 @@ spec:
             - containerPort: {{ .Values.db.service.port }}
           volumeMounts:
             - name: kruize-db-storage
-              mountPath: /var/lib/pgsql/data
+              mountPath: {{ .Values.db.volumeMountPath }}
       volumes:
         - name: kruize-db-storage
           persistentVolumeClaim:

--- a/charts/kruize/templates/kruize_db_deployment.yaml
+++ b/charts/kruize/templates/kruize_db_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.db.user | quote }}
             - name: POSTGRES_DB
-              value: {{ printf "%s-%s" .Values.db.name $fullName | quote }}
+              value: {{ if .Values.db.includeReleaseNameInDbName }}{{ printf "%s-%s" .Values.db.name $fullName | quote }}{{ else }}{{ .Values.db.name | quote }}{{ end }}
             {{- if .Values.db.pgData }}
             - name: PGDATA
               value: {{ .Values.db.pgData }}

--- a/charts/kruize/templates/kruize_db_deployment.yaml
+++ b/charts/kruize/templates/kruize_db_deployment.yaml
@@ -6,15 +6,18 @@ metadata:
   name: {{ include "kruize.deploymentName" . }}-db
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "kruize.labels" . | nindent 4 }}
     app: {{ $fullName }}-db
 spec:
   replicas: 1
   selector:
     matchLabels:
+      {{- include "kruize.selectorLabels" . | nindent 6 }}
       app: {{ $fullName }}-db
   template:
     metadata:
       labels:
+	{{- include "kruize.selectorLabels" . | nindent 8 }}
         app: {{ $fullName }}-db
     spec:
       serviceAccountName: {{ include "kruize.serviceAccountName" . }}

--- a/charts/kruize/templates/kruize_db_deployment.yaml
+++ b/charts/kruize/templates/kruize_db_deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       labels:
-	{{- include "kruize.selectorLabels" . | nindent 8 }}
+        {{- include "kruize.selectorLabels" . | nindent 8 }}
         app: {{ $fullName }}-db
     spec:
       serviceAccountName: {{ include "kruize.serviceAccountName" . }}

--- a/charts/kruize/templates/kruize_db_service.yaml
+++ b/charts/kruize/templates/kruize_db_service.yaml
@@ -15,5 +15,5 @@ spec:
       port: {{ .Values.db.service.port }}
       targetPort: {{ .Values.db.service.port }}
   selector:
-    {{- include "kruize.labels" . | nindent 4 }}
+    {{- include "kruize.selectorLabels" . | nindent 4 }}
     app: {{ $fullName }}-db

--- a/charts/kruize/templates/kruize_db_service.yaml
+++ b/charts/kruize/templates/kruize_db_service.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ $fullName }}-db-service
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "kruize.labels" . | nindent 4 }}
     app: {{ $fullName }}-db
 spec:
   type: {{ .Values.db.service.type }}
@@ -14,4 +15,5 @@ spec:
       port: {{ .Values.db.service.port }}
       targetPort: {{ .Values.db.service.port }}
   selector:
+    {{- include "kruize.labels" . | nindent 4 }}
     app: {{ $fullName }}-db

--- a/charts/kruize/templates/kruize_deployment.yaml
+++ b/charts/kruize/templates/kruize_deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: {{ include "kruize.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}
 spec:
   replicas: {{ .Values.kruize.replicaCount | default 1 }}
   selector:
@@ -14,6 +16,7 @@ spec:
     metadata:
       labels:
         {{- include "kruize.selectorLabels" . | nindent 8 }}
+        app: {{ $fullName }}
     spec:
       serviceAccountName: {{ include "kruize.serviceAccountName" . }}
       initContainers:

--- a/charts/kruize/templates/kruize_service.yaml
+++ b/charts/kruize/templates/kruize_service.yaml
@@ -10,10 +10,12 @@ metadata:
     prometheus.io/path: '/metrics'
   labels:
     {{- include "kruize.labels" . | nindent 4 }}
+    app: {{ $fullName }}
 spec:
   type: {{ .Values.kruize.service.type }}
   selector:
     {{- include "kruize.selectorLabels" . | nindent 4 }}
+    app: {{ $fullName }}
   ports:
     - name: kruize-port
       port: {{ .Values.kruize.service.port }}

--- a/charts/kruize/templates/kruize_ui_nginx_pod.yaml
+++ b/charts/kruize/templates/kruize_ui_nginx_pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $fullName }}-ui-nginx-pod
   namespace: {{ .Release.Namespace }}
   labels:
-    app: kruize-ui-nginx
+    app: {{ $fullName }}-ui-nginx
 spec:
   containers:
     - name: kruize-ui-nginx-container

--- a/charts/kruize/templates/kruize_ui_nginx_service.yaml
+++ b/charts/kruize/templates/kruize_ui_nginx_service.yaml
@@ -5,6 +5,8 @@ kind: Service
 metadata:
   name: {{ $fullName }}-ui-nginx-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}-ui-nginx
 spec:
   type: {{ .Values.kruizeUI.service.type }}
   ports:
@@ -12,4 +14,4 @@ spec:
       port: {{ .Values.kruizeUI.service.port }}
       targetPort: {{ .Values.kruizeUI.service.port }}
   selector:
-    app: kruize-ui-nginx
+    app: {{ $fullName }}-ui-nginx

--- a/charts/kruize/templates/network_policy.yaml
+++ b/charts/kruize/templates/network_policy.yaml
@@ -19,6 +19,7 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "kruize.selectorLabels" . | nindent 14 }}
+              app: {{ $fullName }}
       ports:
         - protocol: TCP
           port: 9090

--- a/charts/kruize/templates/network_policy.yaml
+++ b/charts/kruize/templates/network_policy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled -}}
+{{- $fullName := include "kruize.fullname" . -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-to-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "kruize.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 9090
+{{- end }}

--- a/charts/kruize/templates/rolebinding.yaml
+++ b/charts/kruize/templates/rolebinding.yaml
@@ -14,7 +14,6 @@ roleRef:
   name: {{ $fullName }}-recommendation-updater
 ---
 {{- if .Values.rbac.create }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -56,7 +55,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 {{- if .Values.rbac.create }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/kruize/templates/rolebinding.yaml
+++ b/charts/kruize/templates/rolebinding.yaml
@@ -13,7 +13,8 @@ roleRef:
   kind: ClusterRole
   name: {{ $fullName }}-recommendation-updater
 ---
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -54,7 +55,8 @@ roleRef:
   name: {{ $fullName }}-edit-ko
   apiGroup: rbac.authorization.k8s.io
 ---
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/kruize/templates/rolebinding.yaml
+++ b/charts/kruize/templates/rolebinding.yaml
@@ -26,8 +26,8 @@ roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 ---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -67,4 +67,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "kruize.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
 {{- end }}

--- a/charts/kruize/templates/service_monitor.yaml
+++ b/charts/kruize/templates/service_monitor.yaml
@@ -7,10 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kruize.labels" . | nindent 4 }}
+    app: {{ $fullName }}
 spec:
   selector:
     matchLabels:
       {{- include "kruize.selectorLabels" . | nindent 6 }}
+      app: {{ $fullName }}
   endpoints:
     - port: kruize-port
       interval: {{ .Values.monitoring.interval }}

--- a/charts/kruize/templates/storage_pv.yaml
+++ b/charts/kruize/templates/storage_pv.yaml
@@ -7,12 +7,16 @@ metadata:
   labels:
     type: local
     app: {{ $fullName }}-db
+    {{- include "kruize.labels" . | nindent 4 }}
 
 spec:
   storageClassName: {{ .Values.db.pvc.storageClass | quote }}
   capacity:
     storage: {{ .Values.db.pvc.storageSize | quote }}
   accessModes:
-    - ReadWriteMany
+    {{- toYaml .Values.db.pvc.accessModes | nindent 4 }}
+  {{- if .Values.db.pvc.reclaimPolicy }}
+  persistentVolumeReclaimPolicy: {{ .Values.db.pvc.reclaimPolicy }}
+  {{- end }}
   hostPath:
     path: {{ printf "%s/%s" .Values.db.pvc.hostPath $fullName | quote }}

--- a/charts/kruize/templates/storage_pvc.yaml
+++ b/charts/kruize/templates/storage_pvc.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   storageClassName: {{ .Values.db.pvc.storageClass | quote }}
   accessModes:
-    - ReadWriteMany
+     {{- toYaml .Values.db.pvc.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.db.pvc.storageSize | quote }}

--- a/charts/kruize/values-minikube.yaml
+++ b/charts/kruize/values-minikube.yaml
@@ -1,0 +1,100 @@
+# Minikube-specific values for Kruize Helm Chart
+# This file overrides the default values.yaml for minikube deployments
+
+# Kruize Configuration
+kruize:
+  # Disable resource requests/limits for minikube
+  resources:
+    requests:
+      memory: ""
+      cpu: ""
+    limits:
+      memory: ""
+      cpu: ""
+  
+  config:
+    k8sType: "minikube"
+    
+    # Hibernate configuration - override only changed values
+    hibernate:
+      c3p0minsize: 2
+      c3p0maxsize: 5
+      c3p0maxstatements: 50
+    
+    # Datasource configuration for minikube (single prometheus instance)
+    datasource:
+      - name: "prometheus-1"
+        provider: "prometheus"
+        serviceName: "prometheus-k8s"
+        namespace: "monitoring"
+        url: ""
+        authentication:
+          type: ""
+          credentials:
+            tokenFilePath: ""
+  
+  env:
+    - name: LOGGING_LEVEL
+      value: "info"
+    - name: ROOT_LOGGING_LEVEL
+      value: "error"
+    - name: DB_CONFIG_FILE
+      value: "/etc/config/dbconfigjson"
+    - name: KRUIZE_CONFIG_FILE
+      value: "/etc/config/kruizeconfigjson"
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:MaxRAMPercentage=80"
+    - name: KAFKA_BOOTSTRAP_SERVERS
+      value: "kruize-kafka-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+    - name: KAFKA_TOPICS
+      value: "recommendations-topic,error-topic,summary-topic"
+    - name: KAFKA_RESPONSE_FILTER_INCLUDE
+      value: "summary"
+    - name: KAFKA_RESPONSE_FILTER_EXCLUDE
+      value: ""
+
+# Database Configuration
+db:
+  # Volume mount path for minikube
+  volumeMountPath: "/var/lib/postgresql/data"
+  # Disable PGDATA for minikube
+  pgData: ""
+  
+  # Disable resource requests/limits for minikube
+  resources:
+    requests:
+      memory: ""
+      cpu: ""
+    limits:
+      memory: ""
+      cpu: ""
+  
+  pvc:
+    storageSize: "1Gi"
+    hostPath: "/data/postgres"
+    storageClass: "manual"
+    accessModes:
+      - ReadWriteOnce
+    reclaimPolicy: "Retain"
+
+# RBAC Configuration
+rbac:
+  # Disable OpenShift-specific RBAC resources for minikube
+  create: false
+
+# Service Account Configuration
+serviceAccount:
+  # Use default service account in minikube
+  create: false
+  name: "default"
+
+# Network Policy Configuration
+networkPolicy:
+  # Enable network policy for minikube
+  enabled: true
+
+# Monitoring Configuration
+monitoring:
+  enabled: true
+  interval: 30s
+

--- a/charts/kruize/values.yaml
+++ b/charts/kruize/values.yaml
@@ -141,6 +141,8 @@ db:
     storageClass: manual
     storageSize: "500Mi"
     hostPath: "/mnt/data"
+    accessModes:
+      - ReadWriteMany
   ## @param db.user User for Kruize DB container
   user: admin
   ## @param db.password User for Kruize DB container
@@ -151,6 +153,10 @@ db:
   adminPassword: admin
   ## @param db.name Name of the Kruize DB
   name: kruizeDB
+  ## @param db.volumeMountPath Volume mount path for database data
+  volumeMountPath: "/var/lib/pgsql/data"
+  ## @param db.pgData PGDATA environment variable value
+  pgData: "/var/lib/pg_data"
   sslMode: require
 
 # Kruize UI Configuration
@@ -190,3 +196,7 @@ fullnameOverride: ""
 monitoring:
   enabled: true
   interval: 30s
+
+networkPolicy:
+  ## @param networkPolicy.enabled Enable NetworkPolicy resources
+  enabled: false

--- a/charts/kruize/values.yaml
+++ b/charts/kruize/values.yaml
@@ -153,6 +153,8 @@ db:
   adminPassword: admin
   ## @param db.name Name of the Kruize DB
   name: kruizeDB
+  ## @param db.includeReleaseNameInDbName Include release name in database name for multi-instance support
+  includeReleaseNameInDbName: false
   ## @param db.volumeMountPath Volume mount path for database data
   volumeMountPath: "/var/lib/pgsql/data"
   ## @param db.pgData PGDATA environment variable value


### PR DESCRIPTION
Include helm charts to install Kruize on minikube 

This is on top of #2

## Summary by Sourcery

Add a Helm chart for deploying Kruize and its database/UI components, including Kubernetes manifests, configuration, and storage for running on standard clusters and minikube.

New Features:
- Introduce a configurable Helm chart for deploying the Kruize backend, PostgreSQL database, and UI proxy on Kubernetes clusters.
- Provide minikube-specific Helm values to simplify local Kruize installation with adjusted resources, storage, and RBAC.
- Expose Kruize metrics and services via Service, ServiceMonitor, and optional NetworkPolicy resources for integration with Prometheus.

Enhancements:
- Template cron jobs, configuration maps, RBAC, storage, and health-check resources to fully manage Kruize lifecycle and database maintenance within Helm.
- Document chart usage and configuration options, including example overrides, in a dedicated Helm README.

Documentation:
- Add user-facing documentation describing how to install, configure, and uninstall the Kruize Helm chart, including parameter tables and examples.