### PR TITLE
Add workflow to release Kruize helm chart to Github container registry

### DIFF
--- a/.github/workflows/release_to_ghcr.yml
+++ b/.github/workflows/release_to_ghcr.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-          ref: mvp_demo
     
       - name: Install Helm
         uses: azure/setup-helm@v5.0.0

--- a/.github/workflows/release_to_ghcr.yml
+++ b/.github/workflows/release_to_ghcr.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Push to GHCR
         run: |
-          cd kruize-helm
           echo "helm push kruize-*.tgz oci://ghcr.io/${{ github.repository_owner }}"
           helm push kruize-*.tgz oci://ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/release_to_ghcr.yml
+++ b/.github/workflows/release_to_ghcr.yml
@@ -6,19 +6,21 @@ on:
       - 'v*.*.*'  # Trigger on version tags like v0.1.0
   workflow_dispatch:
 
-permissions:
-  contents: write
-  packages: write
 
 jobs:
   release:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
     
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@v4
+        with:
+          version: 3.14.4
 
       - name: Login to GHCR
         run: |
@@ -30,7 +32,12 @@ jobs:
 
       - name: Push to GHCR
         run: |
-          echo "helm push kruize-*.tgz oci://ghcr.io/${{ github.repository_owner }}"
-          helm push kruize-*.tgz oci://ghcr.io/${{ github.repository_owner }}
+          for pkg in ./*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            echo "helm push ${pkg} oci://ghcr.io/${{ github.repository_owner }}"
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository_owner }}
+          done
 
    

--- a/.github/workflows/release_to_ghcr.yml
+++ b/.github/workflows/release_to_ghcr.yml
@@ -1,0 +1,38 @@
+name: Release Kruize Helm Chart to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Trigger on version tags like v0.1.0
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+          ref: mvp_demo
+    
+      - name: Install Helm
+        uses: azure/setup-helm@v5.0.0
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package Helm Chart
+        run: |
+          helm package charts/kruize
+
+      - name: Push to GHCR
+        run: |
+          cd kruize-helm
+          echo "helm push kruize-*.tgz oci://ghcr.io/${{ github.repository_owner }}"
+          helm push kruize-*.tgz oci://ghcr.io/${{ github.repository_owner }}
+
+   


### PR DESCRIPTION
Add workflow to release Kruize helm chart to Github container registry

## Summary by Sourcery

CI:
- Introduce a release workflow that packages the Kruize Helm chart and pushes it as an OCI artifact to GHCR when semantic version tags are pushed or the workflow is manually triggered.