### PR TITLE
Updates for openshift certification

### DIFF
--- a/charts/kruize/templates/NOTES.txt
+++ b/charts/kruize/templates/NOTES.txt
@@ -1,0 +1,97 @@
+{{- $fullName := include "kruize.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $kruizeServiceType := .Values.kruize.service.type -}}
+{{- $kruizePort := .Values.kruize.service.port -}}
+{{- $uiServiceType := .Values.kruizeUI.service.type -}}
+{{- $uiPort := .Values.kruizeUI.service.port -}}
+
+
+===============================================================================
+THANK YOU FOR INSTALLING {{ .Chart.Name }}!
+===============================================================================
+
+Your release is named {{ .Release.Name }} and installed into the {{ $namespace }} namespace.
+
+{{- if eq $kruizeServiceType "NodePort" }}
+
+To access the Kruize API service, you need to determine the NodePort and Node IP:
+
+  export NODE_PORT=$(kubectl get -n {{ $namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ $fullName }})
+  export NODE_IP=$(kubectl get nodes -n {{ $namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  
+  echo "Kruize API URL: http://$NODE_IP:$NODE_PORT"
+
+{{- else if eq $kruizeServiceType "LoadBalancer" }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get -n {{ $namespace }} svc -w {{ $fullName }}'
+
+  export SERVICE_IP=$(kubectl get svc -n {{ $namespace }} {{ $fullName }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "Kruize API URL: http://$SERVICE_IP:{{ $kruizePort }}"
+
+{{- else if eq $kruizeServiceType "ClusterIP" }}
+
+  Kruize API is available at: http://{{ $fullName }}.{{ $namespace }}.svc.cluster.local:{{ $kruizePort }}
+  
+  To access from outside the cluster, use port-forward:
+  
+  kubectl port-forward -n {{ $namespace }} svc/{{ $fullName }} {{ $kruizePort }}:{{ $kruizePort }}
+  
+  Then visit: http://localhost:{{ $kruizePort }}
+
+{{- end }}
+
+{{- if eq $uiServiceType "NodePort" }}
+
+To access the Kruize UI service:
+
+  export UI_NODE_PORT=$(kubectl get -n {{ $namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ $fullName }}-ui-nginx-service)
+  export NODE_IP=$(kubectl get nodes -n {{ $namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  
+  echo "Kruize UI URL: http://$NODE_IP:$UI_NODE_PORT"
+
+{{- else if eq $uiServiceType "LoadBalancer" }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get -n {{ $namespace }} svc -w {{ $fullName }}-ui-nginx-service'
+
+  export UI_SERVICE_IP=$(kubectl get svc -n {{ $namespace }} {{ $fullName }}-ui-nginx-service --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "Kruize UI URL: http://$UI_SERVICE_IP:{{ $uiPort }}"
+
+{{- else if eq $uiServiceType "ClusterIP" }}
+
+  Kruize UI is available at: http://{{ $fullName }}-ui-nginx-service.{{ $namespace }}.svc.cluster.local:{{ $uiPort }}
+  
+  To access from outside the cluster, use port-forward:
+  
+  kubectl port-forward -n {{ $namespace }} svc/{{ $fullName }}-ui-nginx-service {{ $uiPort }}:{{ $uiPort }}
+  
+  Then visit: http://localhost:{{ $uiPort }}
+
+{{- end }}
+
+To check the status of your deployment:
+
+  kubectl get all -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+To view the Kruize application logs:
+
+  kubectl logs -n {{ $namespace }} -l app={{ $fullName }} -f
+
+To view the Kruize database logs:
+
+  kubectl logs -n {{ $namespace }} -l app={{ $fullName }}-db -f
+
+{{- if .Values.monitoring.enabled }}
+
+Monitoring is enabled. ServiceMonitor has been created for Prometheus integration.
+
+{{- end }}
+
+For more information about Kruize, visit:
+  - Documentation: https://kruize.io/
+  - GitHub: https://github.com/kruize/autotune
+
+To uninstall this release:
+
+  helm uninstall {{ .Release.Name }} -n {{ $namespace }}

--- a/charts/kruize/templates/tests/test-clusterrole.yaml
+++ b/charts/kruize/templates/tests/test-clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- $fullName := include "kruize.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ $fullName }}-test"
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+
+

--- a/charts/kruize/templates/tests/test-clusterrolebinding.yaml
+++ b/charts/kruize/templates/tests/test-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- $fullName := include "kruize.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ $fullName }}-test"
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: "{{ $fullName }}-test"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: "{{ $fullName }}-test"
+  apiGroup: rbac.authorization.k8s.io
+

--- a/charts/kruize/templates/tests/test-connection.yaml
+++ b/charts/kruize/templates/tests/test-connection.yaml
@@ -1,0 +1,64 @@
+{{- $fullName := include "kruize.fullname" . -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ $fullName }}-test-connection"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: "{{ $fullName }}-test"
+  containers:
+    - name: test
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
+      command: ['sh', '-c']
+      args:
+        - |
+          echo "Installing required tools..."
+          microdnf install -y tar gzip
+          
+          # Install kubectl
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+          
+          echo "Getting service information..."
+          export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ $fullName }})
+          export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+          
+          echo "Service: {{ $fullName }}"
+          echo "Namespace: {{ .Release.Namespace }}"
+          echo "Node IP: $NODE_IP"
+          echo "Node Port: $NODE_PORT"
+          echo "Health endpoint: http://$NODE_IP:$NODE_PORT/health"
+          echo ""
+          
+          # Wait for service to be available and healthy
+          echo "Testing Kruize service health..."
+          for i in $(seq 1 10); do
+            HEALTH_STATUS=$(curl -s http://$NODE_IP:$NODE_PORT/health || echo "ERROR")
+            echo "Attempt $i/10: Health status = $HEALTH_STATUS"
+            
+            if echo "$HEALTH_STATUS" | grep -q "UP"; then
+              echo ""
+              echo "✓ Kruize service is UP and accessible at http://$NODE_IP:$NODE_PORT"
+              echo "✓ Health check passed: $HEALTH_STATUS"
+              exit 0
+            fi
+            
+            if [ $i -lt 10 ]; then
+              echo "Waiting for Kruize service to be UP..."
+              sleep 2
+            fi
+          done
+          
+          echo ""
+          echo "✗ Kruize service health check failed after 20 seconds"
+          echo "✗ Last health status: $HEALTH_STATUS"
+          exit 1
+  restartPolicy: Never
+
+

--- a/charts/kruize/templates/tests/test-role.yaml
+++ b/charts/kruize/templates/tests/test-role.yaml
@@ -1,0 +1,17 @@
+{{- $fullName := include "kruize.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ $fullName }}-test"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["services", "nodes"]
+    verbs: ["get", "list"]
+
+

--- a/charts/kruize/templates/tests/test-rolebinding.yaml
+++ b/charts/kruize/templates/tests/test-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- $fullName := include "kruize.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $fullName }}-test"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: "{{ $fullName }}-test"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: "{{ $fullName }}-test"
+  apiGroup: rbac.authorization.k8s.io
+
+

--- a/charts/kruize/templates/tests/test-serviceaccount.yaml
+++ b/charts/kruize/templates/tests/test-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- $fullName := include "kruize.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ $fullName }}-test"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruize.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+


### PR DESCRIPTION
## Summary by Sourcery

Add Helm chart resources to validate Kruize service connectivity using Kubernetes test hooks.

Tests:
- Introduce a Helm test pod that installs kubectl and verifies the Kruize service /health endpoint is reachable via node IP and nodePort.
- Define dedicated test service account, role/cluster role, and corresponding bindings to grant the Helm test pod permissions to read services and nodes.