### PR TITLE
Updated kruize version to latest

### DIFF
--- a/charts/kruize/Chart.yaml
+++ b/charts/kruize/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kruize
 description: Optimize resources used by your containerized workloads
 
-appVersion: "0.9"
+appVersion: "0.11.1"
 home: "https://kruize.io"
 icon: "https://raw.githubusercontent.com/kruize/kruize-helm/main/docs/images/kruize-icon.png"
 

--- a/charts/kruize/README.md
+++ b/charts/kruize/README.md
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the Kruize chart and th
 |-----------|-------------|---------|
 | `kruize.image.repository` | Repository for Kruize container image | `quay.io/kruize/autotune_operator` |
 | `kruize.image.pullPolicy` | Image pull policy for the Kruize container image | `Always` |
-| `kruize.image.tag` | Image tag for Kruize container | `0.9` |
+| `kruize.image.tag` | Image tag for Kruize container | `0.11.1` |
 | `kruize.replicaCount` | Replica count for the Kruize container | `1` |
 | `kruize.resources.requests.memory` | Memory resource request for the Kruize container | `768Mi` |
 | `kruize.resources.requests.cpu` | CPU resource request for the Kruize container | `0.7` |

--- a/charts/kruize/templates/tests/test-connection.yaml
+++ b/charts/kruize/templates/tests/test-connection.yaml
@@ -10,55 +10,46 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  serviceAccountName: "{{ $fullName }}-test"
+  # No custom serviceAccountName needed, satisfying default security policies
   containers:
     - name: test
       image: registry.access.redhat.com/ubi9/ubi-minimal:9.5
       command: ['sh', '-c']
       args:
         - |
-          echo "Installing required tools..."
-          microdnf install -y tar gzip
+          # Safely check if Values.service exists, otherwise default to port 8080
+          {{- $port := 8080 }}
+          {{- if .Values.service }}
+            {{- $port = .Values.service.port | default 8080 }}
+          {{- end }}
           
-          # Install kubectl
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          mv kubectl /usr/local/bin/
+          # Internal Cluster DNS works identically on both Minikube and OpenShift
+          SVC_URL="http://{{ $fullName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ $port }}/health"
           
-          echo "Getting service information..."
-          export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ $fullName }})
-          export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
-          
-          echo "Service: {{ $fullName }}"
-          echo "Namespace: {{ .Release.Namespace }}"
-          echo "Node IP: $NODE_IP"
-          echo "Node Port: $NODE_PORT"
-          echo "Health endpoint: http://$NODE_IP:$NODE_PORT/health"
+          echo "Testing Kruize service health internally..."
+          echo "Target URL: $SVC_URL"
           echo ""
           
-          # Wait for service to be available and healthy
-          echo "Testing Kruize service health..."
           for i in $(seq 1 10); do
-            HEALTH_STATUS=$(curl -s http://$NODE_IP:$NODE_PORT/health || echo "ERROR")
-            echo "Attempt $i/10: Health status = $HEALTH_STATUS"
+            echo "Attempt $i/10..."
             
+            # Execute a clean curl request using the container's native binaries
+            HEALTH_STATUS=$(curl -s --connect-timeout 2 "$SVC_URL" || echo "ERROR")
+            echo "Response: $HEALTH_STATUS"
+            
+            # Check if the endpoint responds with the expected "UP" state
             if echo "$HEALTH_STATUS" | grep -q "UP"; then
               echo ""
-              echo "✓ Kruize service is UP and accessible at http://$NODE_IP:$NODE_PORT"
-              echo "✓ Health check passed: $HEALTH_STATUS"
+              echo "✓ Kruize service is UP and healthy!"
               exit 0
             fi
             
             if [ $i -lt 10 ]; then
-              echo "Waiting for Kruize service to be UP..."
-              sleep 2
+              echo "Waiting for service to stabilize..."
+              sleep 3
             fi
           done
           
-          echo ""
-          echo "✗ Kruize service health check failed after 20 seconds"
-          echo "✗ Last health status: $HEALTH_STATUS"
+          echo "✗ Health check timed out after 10 attempts."
           exit 1
   restartPolicy: Never
-
-

--- a/charts/kruize/tests/with-default-values/cronjobs_test.yaml
+++ b/charts/kruize/tests/with-default-values/cronjobs_test.yaml
@@ -28,7 +28,7 @@ tests:
           value: kruize-cron-create
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "quay.io/kruize/autotune_operator:0.9"
+          value: "quay.io/kruize/autotune_operator:0.11.1"
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
           value: Always
@@ -59,7 +59,7 @@ tests:
           value: kruize-cron-delete
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "quay.io/kruize/autotune_operator:0.9"
+          value: "quay.io/kruize/autotune_operator:0.11.1"
       - contains:
           path: spec.jobTemplate.spec.template.spec.containers[0].env
           content:

--- a/charts/kruize/tests/with-default-values/kruize_service_test.yaml
+++ b/charts/kruize/tests/with-default-values/kruize_service_test.yaml
@@ -23,7 +23,7 @@ tests:
             helm.sh/chart: kruize-0.1.0
             app.kubernetes.io/name: kruize
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/version: "0.9"
+            app.kubernetes.io/version: "0.11.1"
             app.kubernetes.io/managed-by: Helm
       - equal:
           path: metadata.annotations

--- a/charts/kruize/tests/with-default-values/network_policy_test.yaml
+++ b/charts/kruize/tests/with-default-values/network_policy_test.yaml
@@ -31,7 +31,7 @@ tests:
             helm.sh/chart: kruize-0.1.0
             app.kubernetes.io/name: kruize
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/version: "0.9"
+            app.kubernetes.io/version: "0.11.1"
             app.kubernetes.io/managed-by: Helm
       - equal:
           path: spec.podSelector.matchLabels

--- a/charts/kruize/tests/with-default-values/service_monitor_test.yaml
+++ b/charts/kruize/tests/with-default-values/service_monitor_test.yaml
@@ -32,7 +32,7 @@ tests:
             helm.sh/chart: kruize-0.1.0
             app.kubernetes.io/name: kruize
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/version: "0.9"
+            app.kubernetes.io/version: "0.11.1"
             app.kubernetes.io/managed-by: Helm
       - equal:
           path: spec.selector.matchLabels

--- a/charts/kruize/tests/with-minikube-values/kruize_deployment_minikube_test.yaml
+++ b/charts/kruize/tests/with-minikube-values/kruize_deployment_minikube_test.yaml
@@ -29,7 +29,7 @@ tests:
           value: RELEASE-NAME
       - equal:
           path: metadata.labels["app.kubernetes.io/version"]
-          value: "0.9"
+          value: "0.11.1"
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
@@ -77,7 +77,7 @@ tests:
           path: spec.template.spec.containers[?(@.name=='kruize')]
       - equal:
           path: spec.template.spec.containers[?(@.name=='kruize')].image
-          value: "quay.io/kruize/autotune_operator:0.9"
+          value: "quay.io/kruize/autotune_operator:0.11.1"
       - equal:
           path: spec.template.spec.containers[?(@.name=='kruize')].imagePullPolicy
           value: "Always"

--- a/charts/kruize/tests/with-minikube-values/network_policy_minikube_test.yaml
+++ b/charts/kruize/tests/with-minikube-values/network_policy_minikube_test.yaml
@@ -24,7 +24,7 @@ tests:
             helm.sh/chart: kruize-0.1.0
             app.kubernetes.io/name: kruize
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/version: "0.9"
+            app.kubernetes.io/version: "0.11.1"
             app.kubernetes.io/managed-by: Helm
       - equal:
           path: spec.podSelector.matchLabels

--- a/charts/kruize/tests/with-minikube-values/service_monitor_minikube_test.yaml
+++ b/charts/kruize/tests/with-minikube-values/service_monitor_minikube_test.yaml
@@ -25,7 +25,7 @@ tests:
             helm.sh/chart: kruize-0.1.0
             app.kubernetes.io/name: kruize
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/version: "0.9"
+            app.kubernetes.io/version: "0.11.1"
             app.kubernetes.io/managed-by: Helm
       - equal:
           path: spec.selector.matchLabels

--- a/charts/kruize/tests/with-openshift-values/kruize_deployment_test.yaml
+++ b/charts/kruize/tests/with-openshift-values/kruize_deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
           value: RELEASE-NAME
       - equal:
           path: metadata.labels["app.kubernetes.io/version"]
-          value: "0.9"
+          value: "0.11.1"
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
@@ -71,7 +71,7 @@ tests:
           path: spec.template.spec.containers[?(@.name=='kruize')]
       - equal:
           path: spec.template.spec.containers[?(@.name=='kruize')].image
-          value: "quay.io/kruize/autotune_operator:0.9"
+          value: "quay.io/kruize/autotune_operator:0.11.1"
       - equal:
           path: spec.template.spec.containers[?(@.name=='kruize')].imagePullPolicy
           value: "Always"

--- a/charts/kruize/tests/with-openshift-values/rbac_test.yaml
+++ b/charts/kruize/tests/with-openshift-values/rbac_test.yaml
@@ -34,7 +34,7 @@ tests:
             helm.sh/chart: kruize-0.1.0
             app.kubernetes.io/name: kruize
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/version: "0.9"
+            app.kubernetes.io/version: "0.11.1"
             app.kubernetes.io/managed-by: Helm
 
   - it: should use custom ServiceAccount name when specified

--- a/charts/kruize/values.yaml
+++ b/charts/kruize/values.yaml
@@ -8,7 +8,7 @@ kruize:
     ## @param kruize.image.pullPolicy Image pull policy for the Kruize container image
     pullPolicy: Always
     ## @param kruize.image.tag Image tag for Kruize container
-    tag: "0.9"
+    tag: "0.11.1"
   ## @param kruize.replicaCount Replica count for the Kruize container
   replicaCount: 1
   resources:


### PR DESCRIPTION
## Summary by Sourcery

Update Kruize Helm chart to use the latest 0.11.1 release and align health checks and tests with cluster-internal access patterns.

Bug Fixes:
- Ensure Helm test health check targets the Kruize service via internal cluster DNS using the configured service port instead of relying on nodePort and kubectl.

Enhancements:
- Simplify the Helm test-connection pod by removing custom service account requirements and external node-based health probing.
- Update chart metadata and default image tag to Kruize 0.11.1 to reflect the current release.

Documentation:
- Update README to document the new default Kruize image tag 0.11.1.

Tests:
- Refresh Helm chart tests to expect the 0.11.1 image tag and version labels across deployments, services, network policies, service monitors, cronjobs, and RBAC resources.